### PR TITLE
Refine OCR trade parsing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import Tesseract from 'tesseract.js'
+import { clamp, extractAdvancedFields, initialAdvancedInputs } from './lib/ocr'
 import './App.css'
 
 const WEIGHTS = {
@@ -60,17 +61,6 @@ const ADVANCED_CLASSES = [
   },
 ]
 
-const initialAdvancedInputs = {
-  walletSize: '',
-  pnl: '',
-  unrealizedPnl: '',
-  totalTrades: '',
-  winTrades: '',
-  lossTrades: '',
-  date: '',
-  carry: '',
-}
-
 const initialWeightInputs = {
   founder: '50',
   investor: '35',
@@ -94,8 +84,6 @@ const integerFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 })
 
-const clamp = (value, min, max) => Math.min(max, Math.max(min, value))
-
 const formatCurrency = (value) => currencyFormatter.format(value)
 const formatPercent = (value) => percentFormatter.format(value)
 const formatInteger = (value) => integerFormatter.format(value)
@@ -113,177 +101,6 @@ const calcSplit = (profit, carryPct, scenarioKey) => {
   const total = founders + laura + damon
 
   return { founders, laura, damon, total, weights }
-}
-
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-const normalizeMagnitude = (raw) => {
-  if (!raw) return ''
-  const trimmed = raw.trim()
-  const magnitudeMatch = trimmed.match(/([kKmM])$/)
-  const isNegative = trimmed.startsWith('(') && trimmed.endsWith(')')
-  const sanitized = trimmed.replace(/[^0-9.+-]/g, '')
-  if (!sanitized) return ''
-  let numeric = Number(sanitized)
-  if (Number.isNaN(numeric)) return ''
-  if (isNegative && numeric > 0) {
-    numeric *= -1
-  }
-  if (!magnitudeMatch) {
-    return String(numeric)
-  }
-  const mag = magnitudeMatch[1].toLowerCase()
-  const multiplier = mag === 'k' ? 1_000 : 1_000_000
-  return String(numeric * multiplier)
-}
-
-const numericTokenRegex = /([-+]?[$]?\d[\d,]*(?:\.\d+)?(?:\s?[kKmM])?)/
-const percentTokenRegex = /([-+]?\d+(?:\.\d+)?)\s*%/
-
-const parseLabeledNumber = (text, labels) => {
-  const lines = text.split(/\r?\n/).map((line) => line.trim())
-
-  for (const label of labels) {
-    const labelLower = label.toLowerCase()
-    for (let index = 0; index < lines.length; index += 1) {
-      const current = lines[index]
-      const currentLower = current.toLowerCase()
-      if (!currentLower.includes(labelLower)) {
-        continue
-      }
-      const inlineMatch = current.match(numericTokenRegex)
-      if (inlineMatch?.[1]) {
-        const normalized = normalizeMagnitude(inlineMatch[1])
-        if (normalized) return normalized
-      }
-      const nextLine = lines[index + 1]
-      if (nextLine) {
-        const nextMatch = nextLine.match(numericTokenRegex)
-        if (nextMatch?.[1]) {
-          const normalized = normalizeMagnitude(nextMatch[1])
-          if (normalized) return normalized
-        }
-      }
-    }
-  }
-
-  for (const label of labels) {
-    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${numericTokenRegex.source}`, 'i')
-    const match = regex.exec(text)
-    if (match?.[1]) {
-      const normalized = normalizeMagnitude(match[1])
-      if (normalized) return normalized
-    }
-  }
-
-  return ''
-}
-
-const parsePercentage = (text, labels) => {
-  const lines = text.split(/\r?\n/).map((line) => line.trim())
-
-  for (const label of labels) {
-    const labelLower = label.toLowerCase()
-    for (let index = 0; index < lines.length; index += 1) {
-      const current = lines[index]
-      const currentLower = current.toLowerCase()
-      if (!currentLower.includes(labelLower)) {
-        continue
-      }
-      const inlineMatch = current.match(percentTokenRegex)
-      if (inlineMatch?.[1]) {
-        return inlineMatch[1]
-      }
-      const nextLine = lines[index + 1]
-      if (nextLine) {
-        const nextMatch = nextLine.match(percentTokenRegex)
-        if (nextMatch?.[1]) {
-          return nextMatch[1]
-        }
-      }
-    }
-  }
-
-  for (const label of labels) {
-    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${percentTokenRegex.source}`, 'i')
-    const match = regex.exec(text)
-    if (match?.[1]) {
-      return match[1]
-    }
-  }
-
-  return ''
-}
-
-const parseDate = (text) => {
-  const iso = text.match(/\b\d{4}-\d{2}-\d{2}\b/)
-  if (iso) return iso[0]
-
-  const slash = text.match(/\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/)
-  if (slash) return slash[0]
-
-  const month = text.match(
-    /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2},?\s+\d{2,4}\b/i,
-  )
-  if (month) return month[0]
-
-  return ''
-}
-
-const extractAdvancedFields = (text) => {
-  if (!text) {
-    return initialAdvancedInputs
-  }
-
-  const normalizedText = text.replace(/\r?\n/g, '\n')
-
-  const walletSize = parseLabeledNumber(normalizedText, [
-    'wallet size',
-    'wallet balance',
-    'wallet',
-  ])
-  const pnl = parseLabeledNumber(normalizedText, [
-    'realized pnl',
-    'net pnl',
-    'pnl',
-    'p/l',
-    'profit',
-  ])
-  const unrealizedPnl = parseLabeledNumber(normalizedText, [
-    'unrealized pnl',
-    'unrealized p/l',
-    'unrealized',
-  ])
-  const totalTrades = parseLabeledNumber(normalizedText, [
-    'total trades',
-    'trades total',
-    'trade count',
-    'trades',
-  ])
-  const winTrades = parseLabeledNumber(normalizedText, [
-    'win trades',
-    'winning trades',
-    'wins',
-  ])
-  const lossTrades = parseLabeledNumber(normalizedText, [
-    'loss trades',
-    'losing trades',
-    'losses',
-  ])
-  const carryRaw = parsePercentage(normalizedText, ['carry', 'carry %', 'carry percent'])
-  const carry = carryRaw ? String(clamp(Number(carryRaw) || 0, 0, 100)) : ''
-  const date = parseDate(text)
-
-  return {
-    walletSize,
-    pnl,
-    unrealizedPnl,
-    totalTrades,
-    winTrades,
-    lossTrades,
-    date,
-    carry,
-  }
 }
 
 const sanitizeNumericInput = (value) => {

--- a/src/lib/ocr.js
+++ b/src/lib/ocr.js
@@ -1,0 +1,353 @@
+export const initialAdvancedInputs = {
+  walletSize: '',
+  pnl: '',
+  unrealizedPnl: '',
+  totalTrades: '',
+  winTrades: '',
+  lossTrades: '',
+  date: '',
+  carry: '',
+}
+
+export const clamp = (value, min, max) => Math.min(max, Math.max(min, value))
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const normalizeMagnitude = (raw) => {
+  if (!raw) return ''
+  const trimmed = raw.trim()
+  const magnitudeMatch = trimmed.match(/([kKmM])$/)
+  const isNegative = trimmed.startsWith('(') && trimmed.endsWith(')')
+  const sanitized = trimmed.replace(/[^0-9.+-]/g, '')
+  if (!sanitized) return ''
+  let numeric = Number(sanitized)
+  if (Number.isNaN(numeric)) return ''
+  if (isNegative && numeric > 0) {
+    numeric *= -1
+  }
+  if (!magnitudeMatch) {
+    return String(numeric)
+  }
+  const mag = magnitudeMatch[1].toLowerCase()
+  const multiplier = mag === 'k' ? 1_000 : 1_000_000
+  return String(numeric * multiplier)
+}
+
+const numericTokenRegex = /([-+]?[$]?\d[\d,]*(?:\.\d+)?(?:\s?[kKmM])?)/
+const percentTokenRegex = /([-+]?\d+(?:\.\d+)?)\s*%/
+
+const winLossKeywords = ['win', 'wins', 'winning', 'loss', 'losses', 'losing', 'lost', 'lose', 'loses', 'won']
+
+const hasWinLossKeyword = (value) => {
+  if (!value) return false
+  const lower = value.toLowerCase()
+  return winLossKeywords.some((keyword) => lower.includes(keyword))
+}
+
+const hasTradeSummaryIndicator = (value) => {
+  if (!value) return false
+  const lower = value.toLowerCase()
+  if (!lower.includes('trade')) {
+    return false
+  }
+  if (hasWinLossKeyword(lower)) {
+    return false
+  }
+  if (/\btotal\b/.test(lower)) {
+    return true
+  }
+  if (/\boverall\b/.test(lower)) {
+    return true
+  }
+  if (/\bcount\b/.test(lower) || /\bcounts\b/.test(lower)) {
+    return true
+  }
+  if (/\bnumber\b/.test(lower)) {
+    return true
+  }
+  if (/\bno\.?\b/.test(lower)) {
+    return true
+  }
+  if (lower.includes('#')) {
+    return true
+  }
+  return false
+}
+
+const parseLabeledNumber = (text, labels) => {
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+
+  for (const label of labels) {
+    const labelLower = label.toLowerCase()
+    for (let index = 0; index < lines.length; index += 1) {
+      const current = lines[index]
+      const currentLower = current.toLowerCase()
+      if (!currentLower.includes(labelLower)) {
+        continue
+      }
+      const inlineMatch = current.match(numericTokenRegex)
+      if (inlineMatch?.[1]) {
+        const normalized = normalizeMagnitude(inlineMatch[1])
+        if (normalized) return normalized
+      }
+      const nextLine = lines[index + 1]
+      if (nextLine) {
+        const nextMatch = nextLine.match(numericTokenRegex)
+        if (nextMatch?.[1]) {
+          const normalized = normalizeMagnitude(nextMatch[1])
+          if (normalized) return normalized
+        }
+      }
+    }
+  }
+
+  for (const label of labels) {
+    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${numericTokenRegex.source}`, 'gi')
+    let match = regex.exec(text)
+    while (match) {
+      const normalized = normalizeMagnitude(match[1])
+      if (normalized) {
+        return normalized
+      }
+      match = regex.exec(text)
+    }
+  }
+
+  return ''
+}
+
+const parsePercentage = (text, labels) => {
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+
+  for (const label of labels) {
+    const labelLower = label.toLowerCase()
+    for (let index = 0; index < lines.length; index += 1) {
+      const current = lines[index]
+      const currentLower = current.toLowerCase()
+      if (!currentLower.includes(labelLower)) {
+        continue
+      }
+      const inlineMatch = current.match(percentTokenRegex)
+      if (inlineMatch?.[1]) {
+        return inlineMatch[1]
+      }
+      const nextLine = lines[index + 1]
+      if (nextLine) {
+        const nextMatch = nextLine.match(percentTokenRegex)
+        if (nextMatch?.[1]) {
+          return nextMatch[1]
+        }
+      }
+    }
+  }
+
+  for (const label of labels) {
+    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${percentTokenRegex.source}`, 'gi')
+    let match = regex.exec(text)
+    while (match) {
+      if (match?.[1]) {
+        return match[1]
+      }
+      match = regex.exec(text)
+    }
+  }
+
+  return ''
+}
+
+const parseDate = (text) => {
+  const iso = text.match(/\b\d{4}-\d{2}-\d{2}\b/)
+  if (iso) return iso[0]
+
+  const slash = text.match(/\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/)
+  if (slash) return slash[0]
+
+  const month = text.match(
+    /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2},?\s+\d{2,4}\b/i,
+  )
+  if (month) return month[0]
+
+  return ''
+}
+
+const parseTotalTrades = (text) => {
+  if (!text) return ''
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+
+  const parseFromLine = (line) => {
+    if (!hasTradeSummaryIndicator(line)) {
+      return ''
+    }
+    const inlineMatch = line.match(numericTokenRegex)
+    if (inlineMatch?.[1]) {
+      const normalized = normalizeMagnitude(inlineMatch[1])
+      if (normalized) {
+        return normalized
+      }
+    }
+    return ''
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const current = lines[index]
+    if (!current) {
+      continue
+    }
+    const currentResult = parseFromLine(current)
+    if (currentResult) {
+      const currentLower = current.toLowerCase()
+      if (currentLower && currentLower.includes('total') && !currentLower.match(/\d/)) {
+        const nextLine = lines[index + 1]
+        if (nextLine && !hasWinLossKeyword(nextLine)) {
+          const nextMatch = nextLine.match(numericTokenRegex)
+          if (nextMatch?.[1]) {
+            const normalized = normalizeMagnitude(nextMatch[1])
+            if (normalized) {
+              return normalized
+            }
+          }
+        }
+      } else {
+        return currentResult
+      }
+    }
+
+    const currentLower = current.toLowerCase()
+    if (/\btotal\b/.test(currentLower) && !currentLower.includes('trade')) {
+      const nextLine = lines[index + 1]
+      if (nextLine) {
+        const nextLower = nextLine.toLowerCase()
+        if (nextLower.includes('trade') && !hasWinLossKeyword(nextLower)) {
+          const nextResult = parseFromLine(nextLine)
+          if (nextResult) {
+            return nextResult
+          }
+          const inlineNextMatch = nextLine.match(numericTokenRegex)
+          if (inlineNextMatch?.[1]) {
+            const normalized = normalizeMagnitude(inlineNextMatch[1])
+            if (normalized) {
+              return normalized
+            }
+          }
+          const following = lines[index + 2]
+          if (following && !hasWinLossKeyword(following)) {
+            const followingMatch = following.match(numericTokenRegex)
+            if (followingMatch?.[1]) {
+              const normalized = normalizeMagnitude(followingMatch[1])
+              if (normalized) {
+                return normalized
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (hasTradeSummaryIndicator(currentLower)) {
+      const nextLine = lines[index + 1]
+      if (nextLine && !hasWinLossKeyword(nextLine)) {
+        const nextMatch = nextLine.match(numericTokenRegex)
+        if (nextMatch?.[1]) {
+          const normalized = normalizeMagnitude(nextMatch[1])
+          if (normalized) {
+            return normalized
+          }
+        }
+      }
+    }
+  }
+
+  const regexes = [
+    new RegExp(
+      `\\btotal(?:\\s+\\w+){0,3}\\s+trades?\\b[\\s:=\u2013-]*${numericTokenRegex.source}`,
+      'gi',
+    ),
+    new RegExp(
+      `\\btrades?\\b(?:\\s+\\w+){0,3}\\s+total\\b[\\s:=\u2013-]*${numericTokenRegex.source}`,
+      'gi',
+    ),
+  ]
+
+  for (const regex of regexes) {
+    let match = regex.exec(text)
+    while (match) {
+      const segment = match[0]?.toLowerCase?.() ?? ''
+      if (!segment || hasWinLossKeyword(segment)) {
+        match = regex.exec(text)
+        continue
+      }
+      const normalized = normalizeMagnitude(match[1])
+      if (normalized) {
+        return normalized
+      }
+      match = regex.exec(text)
+    }
+  }
+
+  return ''
+}
+
+export const extractAdvancedFields = (text) => {
+  if (!text) {
+    return initialAdvancedInputs
+  }
+
+  const normalizedText = text.replace(/\r?\n/g, '\n')
+
+  const walletSize = parseLabeledNumber(normalizedText, [
+    'wallet size',
+    'wallet balance',
+    'wallet',
+  ])
+  const pnl = parseLabeledNumber(normalizedText, [
+    'realized pnl',
+    'net pnl',
+    'pnl',
+    'p/l',
+    'profit',
+  ])
+  const unrealizedPnl = parseLabeledNumber(normalizedText, [
+    'unrealized pnl',
+    'unrealized p/l',
+    'unrealized',
+  ])
+
+  const winTrades = parseLabeledNumber(normalizedText, [
+    'win trades',
+    'winning trades',
+    'win trade count',
+    'winning trade count',
+    'win count',
+    'wins',
+  ])
+  const lossTrades = parseLabeledNumber(normalizedText, [
+    'loss trades',
+    'losing trades',
+    'loss trade count',
+    'losing trade count',
+    'loss count',
+    'losses',
+  ])
+  const totalTrades =
+    parseTotalTrades(normalizedText) ||
+    parseLabeledNumber(normalizedText, [
+      'total trade count',
+      'count of trades',
+      'number of trades',
+    ])
+
+  const carryRaw = parsePercentage(normalizedText, ['carry', 'carry %', 'carry percent'])
+  const carry = carryRaw ? String(clamp(Number(carryRaw) || 0, 0, 100)) : ''
+  const date = parseDate(text)
+
+  return {
+    walletSize,
+    pnl,
+    unrealizedPnl,
+    totalTrades,
+    winTrades,
+    lossTrades,
+    date,
+    carry,
+  }
+}

--- a/tests/ocr-parsing.test.js
+++ b/tests/ocr-parsing.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { extractAdvancedFields } from '../src/lib/ocr.js'
+
+test('extracts independent trade counts from inline totals', () => {
+  const sample = [
+    'Wallet Size $5,000',
+    'Total trades – 24',
+    'Win trades: 18',
+    'Loss trades: 6',
+  ].join('\n')
+
+  const fields = extractAdvancedFields(sample)
+
+  assert.equal(fields.totalTrades, '24')
+  assert.equal(fields.winTrades, '18')
+  assert.equal(fields.lossTrades, '6')
+})
+
+test('handles separated total labels without confusing win/loss values', () => {
+  const sample = [
+    'Total trades',
+    '30',
+    'Winning trades: 20',
+    'Losing trades: 10',
+  ].join('\n')
+
+  const fields = extractAdvancedFields(sample)
+
+  assert.equal(fields.totalTrades, '30')
+  assert.equal(fields.winTrades, '20')
+  assert.equal(fields.lossTrades, '10')
+})
+
+test('supports descriptive count phrasing while keeping counts distinct', () => {
+  const sample = [
+    'Count of trades 42',
+    'Winning trades 33',
+    'Losing trades 9',
+  ].join('\n')
+
+  const fields = extractAdvancedFields(sample)
+
+  assert.equal(fields.totalTrades, '42')
+  assert.equal(fields.winTrades, '33')
+  assert.equal(fields.lossTrades, '9')
+})
+
+test('does not reuse win totals when a total trade count is missing', () => {
+  const sample = [
+    'Winning trade count: 17',
+    'Loss trades: 5',
+  ].join('\n')
+
+  const fields = extractAdvancedFields(sample)
+
+  assert.equal(fields.totalTrades, '')
+  assert.equal(fields.winTrades, '17')
+  assert.equal(fields.lossTrades, '5')
+})


### PR DESCRIPTION
## Summary
- move OCR parsing helpers into `src/lib/ocr.js` so the app can import shared logic and clamp utilities
- tighten total trade extraction to look for "total"-specific trade cues and expanded win/loss labels to avoid collisions
- add node-based tests that verify total, win, and loss trade counts remain independent on OCR samples

## Testing
- npm run lint
- node --test tests/ocr-parsing.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c9a30068fc83328606c2004cac6fb9