### PR TITLE
Use realized PnL for advanced allocations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -310,6 +310,7 @@ function AdvancedFieldsSection({
   normalizedWeights,
   advancedDistribution,
   advancedNumbers,
+  realizedProfit,
   combinedProfit,
   roi,
   winRate,
@@ -504,10 +505,10 @@ function AdvancedFieldsSection({
                 <dd>{formatPercent(normalizedWeights[classification.key])}</dd>
               </div>
               <div>
-                <dt>Share of combined PnL</dt>
+                <dt>Share of realized PnL</dt>
                 <dd>
-                  {combinedProfit !== 0
-                    ? formatPercent((advancedDistribution[classification.key] / combinedProfit || 0))
+                  {realizedProfit !== 0
+                    ? formatPercent((advancedDistribution[classification.key] / realizedProfit || 0))
                     : formatPercent(0)}
                 </dd>
               </div>
@@ -531,7 +532,7 @@ function AdvancedFieldsSection({
             <dd>{formatCurrency(advancedNumbers.unrealizedPnl)}</dd>
           </div>
           <div>
-            <dt>Combined PnL</dt>
+            <dt>Total PnL (realized + unrealized)</dt>
             <dd>{formatCurrency(combinedProfit)}</dd>
           </div>
           <div>
@@ -731,11 +732,12 @@ function App() {
       }
     : { founder: 0, investor: 0, moonbag: 0 }
 
-  const combinedProfit = advancedNumbers.pnl + advancedNumbers.unrealizedPnl
+  const realizedProfit = advancedNumbers.pnl
+  const combinedProfit = realizedProfit + advancedNumbers.unrealizedPnl
   const advancedDistribution = {
-    founder: combinedProfit * normalizedWeights.founder,
-    investor: combinedProfit * normalizedWeights.investor,
-    moonbag: combinedProfit * normalizedWeights.moonbag,
+    founder: realizedProfit * normalizedWeights.founder,
+    investor: realizedProfit * normalizedWeights.investor,
+    moonbag: realizedProfit * normalizedWeights.moonbag,
   }
 
   const winRate = advancedNumbers.totalTrades > 0 ? advancedNumbers.winTrades / advancedNumbers.totalTrades : 0
@@ -1141,6 +1143,7 @@ function App() {
             normalizedWeights={normalizedWeights}
             advancedDistribution={advancedDistribution}
             advancedNumbers={advancedNumbers}
+            realizedProfit={realizedProfit}
             combinedProfit={combinedProfit}
             roi={roi}
             winRate={winRate}
@@ -1217,6 +1220,7 @@ function App() {
             normalizedWeights={normalizedWeights}
             advancedDistribution={advancedDistribution}
             advancedNumbers={advancedNumbers}
+            realizedProfit={realizedProfit}
             combinedProfit={combinedProfit}
             roi={roi}
             winRate={winRate}


### PR DESCRIPTION
## Summary
- base the advanced investor-class distribution on realized PnL instead of combined profits
- adjust UI copy and share calculations to reflect realized-only allocations while keeping total PnL for display metrics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9af7e94c08332be7b7cb24c6c276d