### PR TITLE
Automate moonbag routing with capital history

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -696,6 +696,49 @@ select:focus {
   font-size: 0.85rem;
 }
 
+.weights-summary.capital-history {
+  background: rgba(12, 18, 28, 0.6);
+  border: 1px solid rgba(35, 48, 71, 0.6);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.8rem;
+}
+
+.capital-history-heading {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.capital-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.capital-history-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.capital-history-text {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.capital-history-values {
+  font-variant-numeric: tabular-nums;
+  color: #d7e0ea;
+}
+
 .advanced-metrics {
   margin-top: 18px;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- add a canonical capital history timeline and derive scenario weights from that data
- automatically split the moonbag class 75/25 between founders and the investor pool, and apportion the investor share by capital contributions
- surface the computed weights, moonbag routing, and capital timeline inside the advanced metrics panel for transparency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9a9f22b3c8332ba6828334e2f4074