### PR TITLE
Normalize OCR date parsing and add coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test tests/parse-date.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import Tesseract from 'tesseract.js'
+import { parseDate } from './utils/parseDate.js'
 import './App.css'
 
 const WEIGHTS = {
@@ -215,21 +216,6 @@ const parsePercentage = (text, labels) => {
   return ''
 }
 
-const parseDate = (text) => {
-  const iso = text.match(/\b\d{4}-\d{2}-\d{2}\b/)
-  if (iso) return iso[0]
-
-  const slash = text.match(/\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/)
-  if (slash) return slash[0]
-
-  const month = text.match(
-    /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2},?\s+\d{2,4}\b/i,
-  )
-  if (month) return month[0]
-
-  return ''
-}
-
 const extractAdvancedFields = (text) => {
   if (!text) {
     return initialAdvancedInputs
@@ -272,7 +258,7 @@ const extractAdvancedFields = (text) => {
   ])
   const carryRaw = parsePercentage(normalizedText, ['carry', 'carry %', 'carry percent'])
   const carry = carryRaw ? String(clamp(Number(carryRaw) || 0, 0, 100)) : ''
-  const date = parseDate(text)
+  const date = parseDate(normalizedText)
 
   return {
     walletSize,

--- a/src/utils/parseDate.js
+++ b/src/utils/parseDate.js
@@ -1,0 +1,150 @@
+const monthIndexByName = {
+  jan: 1,
+  january: 1,
+  feb: 2,
+  february: 2,
+  mar: 3,
+  march: 3,
+  apr: 4,
+  april: 4,
+  may: 5,
+  jun: 6,
+  june: 6,
+  jul: 7,
+  july: 7,
+  aug: 8,
+  august: 8,
+  sep: 9,
+  sept: 9,
+  september: 9,
+  oct: 10,
+  october: 10,
+  nov: 11,
+  november: 11,
+  dec: 12,
+  december: 12,
+}
+
+const monthNamePattern =
+  '(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)'
+
+const ordinalSuffixRegex = /(st|nd|rd|th)$/i
+
+const normalizeYear = (value) => {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    return null
+  }
+  if (numeric < 0) {
+    return null
+  }
+  if (numeric < 100) {
+    return 2000 + numeric
+  }
+  if (numeric >= 1000 && numeric <= 9999) {
+    return numeric
+  }
+  return null
+}
+
+const normalizeMonth = (value) => {
+  if (value == null) {
+    return null
+  }
+  const cleaned = String(value).trim().toLowerCase().replace(/\.$/, '')
+  const mapped = monthIndexByName[cleaned]
+  if (mapped) {
+    return mapped
+  }
+  const numeric = Number(cleaned)
+  if (!Number.isInteger(numeric)) {
+    return null
+  }
+  if (numeric < 1 || numeric > 12) {
+    return null
+  }
+  return numeric
+}
+
+const normalizeDay = (value) => {
+  if (value == null) {
+    return null
+  }
+  const cleaned = String(value).trim().replace(ordinalSuffixRegex, '')
+  const numeric = Number(cleaned)
+  if (!Number.isInteger(numeric)) {
+    return null
+  }
+  if (numeric < 1 || numeric > 31) {
+    return null
+  }
+  return numeric
+}
+
+const isValidDate = (year, month, day) => {
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  )
+}
+
+const buildIsoDate = (yearInput, monthInput, dayInput) => {
+  const year = normalizeYear(yearInput)
+  const month = normalizeMonth(monthInput)
+  const day = normalizeDay(dayInput)
+  if (year == null || month == null || day == null) {
+    return ''
+  }
+  if (!isValidDate(year, month, day)) {
+    return ''
+  }
+  const isoYear = String(year).padStart(4, '0')
+  const isoMonth = String(month).padStart(2, '0')
+  const isoDay = String(day).padStart(2, '0')
+  return `${isoYear}-${isoMonth}-${isoDay}`
+}
+
+const isoDateRegex = /\b\d{4}-\d{2}-\d{2}\b/
+const slashDateRegex = /\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/
+const monthDateRegex = new RegExp(
+  `\\b(?<month>${monthNamePattern})(?:\\.)?\\s+(?<day>\\d{1,2}(?:st|nd|rd|th)?)?,?\\s+(?<year>\\d{2,4})\\b`,
+  'i',
+)
+
+export const parseDate = (text) => {
+  if (!text) {
+    return ''
+  }
+
+  const isoMatch = text.match(isoDateRegex)
+  if (isoMatch?.[0]) {
+    return isoMatch[0]
+  }
+
+  const slashMatch = text.match(slashDateRegex)
+  if (slashMatch?.[0]) {
+    const [monthPart, dayPart, yearPart] = slashMatch[0].split(/[/-]/)
+    const normalized = buildIsoDate(yearPart, monthPart, dayPart)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  const monthMatch = monthDateRegex.exec(text)
+  if (monthMatch) {
+    const groups = monthMatch.groups || {}
+    const monthPart = groups.month || monthMatch[1]
+    const dayPart = groups.day || monthMatch[2]
+    const yearPart = groups.year || monthMatch[3]
+    const normalized = buildIsoDate(yearPart, monthPart, dayPart)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  return ''
+}
+
+export default parseDate

--- a/tests/parse-date.test.js
+++ b/tests/parse-date.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseDate } from '../src/utils/parseDate.js'
+
+test('returns ISO dates when already formatted', () => {
+  const input = 'Snapshot captured on 2025-08-02 for review.'
+  assert.equal(parseDate(input), '2025-08-02')
+})
+
+test('normalizes slash-delimited dates', () => {
+  const input = 'Report period: 08/02/2025 summary.'
+  assert.equal(parseDate(input), '2025-08-02')
+})
+
+test('normalizes two-digit years from slash-delimited dates', () => {
+  const input = 'Report period: 08/02/25 summary.'
+  assert.equal(parseDate(input), '2025-08-02')
+})
+
+test('parses textual months without punctuation', () => {
+  const input = 'Performance through Aug 2 2025 is included.'
+  assert.equal(parseDate(input), '2025-08-02')
+})
+
+test('parses Figment-style month abbreviations with periods and ordinals', () => {
+  const input = 'Figment snapshot • Aug. 2nd 2025 • Wallet update'
+  assert.equal(parseDate(input), '2025-08-02')
+})
+
+test('normalizes two-digit years from textual dates', () => {
+  const input = 'Stats as of Aug. 2nd, 25 with new capital.'
+  assert.equal(parseDate(input), '2025-08-02')
+})
+
+test('parses alternate abbreviations with periods', () => {
+  const input = 'Highlights through Sept. 3rd 2025 show growth.'
+  assert.equal(parseDate(input), '2025-09-03')
+})
+
+test('ignores unmatched text', () => {
+  const input = 'No valid date appears in this text block.'
+  assert.equal(parseDate(input), '')
+})


### PR DESCRIPTION
## Summary
- move the OCR date parsing logic into a dedicated utility and normalize all matches to ISO strings before storing them
- expand the regex handling to cover month abbreviations with periods and ordinal day suffixes seen in Figment exports
- add a Node-based test harness that exercises the new parsing cases, including the previously skipped Figment examples

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9af8364508332b55ab0ca0a930414