### PR TITLE
Add AI toggles to OCR upload panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -655,6 +655,82 @@ select:focus {
   resize: vertical;
 }
 
+.ai-toggle-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px;
+  margin: -4px 0 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(35, 48, 71, 0.6);
+  background: rgba(17, 25, 38, 0.65);
+}
+
+.ai-toggle {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(35, 48, 71, 0.6);
+  background: rgba(11, 14, 20, 0.6);
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition), box-shadow var(--transition),
+    transform var(--transition);
+}
+
+.ai-toggle:hover {
+  border-color: rgba(57, 208, 216, 0.45);
+  background: rgba(23, 33, 51, 0.75);
+  transform: translateY(-1px);
+}
+
+.ai-toggle:focus-within {
+  outline: none;
+  border-color: rgba(57, 208, 216, 0.6);
+  box-shadow: 0 0 0 3px rgba(57, 208, 216, 0.35);
+}
+
+.ai-toggle.disabled,
+.ai-toggle.disabled:hover {
+  cursor: not-allowed;
+  border-color: rgba(35, 48, 71, 0.6);
+  background: rgba(17, 24, 34, 0.55);
+  box-shadow: none;
+  transform: none;
+}
+
+.ai-toggle input {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: var(--accent);
+  cursor: inherit;
+}
+
+.ai-toggle.disabled input {
+  cursor: not-allowed;
+}
+
+.ai-toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ai-toggle-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #d7e0ea;
+}
+
+.ai-toggle-subtext {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
 .upload-actions {
   display: flex;
   gap: 12px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -587,12 +587,23 @@ function App() {
   const [aiStatus, setAiStatus] = useState('idle')
   const [aiError, setAiError] = useState('')
   const [aiReport, setAiReport] = useState('')
+  const [useAiExtraction, setUseAiExtraction] = useState(false)
+  const [useAiVision, setUseAiVision] = useState(false)
 
   useEffect(() => () => {
     if (uploadedImage && typeof URL !== 'undefined') {
       URL.revokeObjectURL(uploadedImage)
     }
   }, [uploadedImage])
+
+  useEffect(() => {
+    if (!aiKey) {
+      setUseAiExtraction(false)
+      setUseAiVision(false)
+    }
+  }, [aiKey])
+
+  const isAiControlsDisabled = !aiKey
 
   const handleProfitChange = (event) => {
     setProfitInput(event.target.value)
@@ -1161,6 +1172,42 @@ function App() {
               Drop a Figment dashboard screenshot to automatically extract wallet size, PnL, trade counts, and carry. All OCR runs in the
               browser via Tesseract.js.
             </p>
+            <div className="ai-toggle-row" role="group" aria-label="AI-assisted OCR options">
+              <label
+                className={`ai-toggle${isAiControlsDisabled ? ' disabled' : ''}`}
+                aria-disabled={isAiControlsDisabled ? 'true' : 'false'}
+                title={isAiControlsDisabled ? 'Enter API key to enable.' : undefined}
+              >
+                <input
+                  type="checkbox"
+                  checked={useAiExtraction}
+                  onChange={(event) => setUseAiExtraction(event.target.checked)}
+                  disabled={isAiControlsDisabled}
+                  title={isAiControlsDisabled ? 'Enter API key to enable.' : undefined}
+                />
+                <span className="ai-toggle-text">
+                  <span className="ai-toggle-title">Use AI extraction</span>
+                  <span className="ai-toggle-subtext">Clean OCR fields with an LLM pass.</span>
+                </span>
+              </label>
+              <label
+                className={`ai-toggle${isAiControlsDisabled ? ' disabled' : ''}`}
+                aria-disabled={isAiControlsDisabled ? 'true' : 'false'}
+                title={isAiControlsDisabled ? 'Enter API key to enable.' : undefined}
+              >
+                <input
+                  type="checkbox"
+                  checked={useAiVision}
+                  onChange={(event) => setUseAiVision(event.target.checked)}
+                  disabled={isAiControlsDisabled}
+                  title={isAiControlsDisabled ? 'Enter API key to enable.' : undefined}
+                />
+                <span className="ai-toggle-text">
+                  <span className="ai-toggle-title">Use AI vision</span>
+                  <span className="ai-toggle-subtext">Send the screenshot to a vision model.</span>
+                </span>
+              </label>
+            </div>
             <label className={`upload-zone ${ocrStatus === 'processing' ? 'uploading' : ''}`}>
               <input type="file" accept="image/*" onChange={handleOcrUpload} />
               <span>


### PR DESCRIPTION
## Summary
- add state for AI extraction and vision toggles tied to the Upload & OCR workflow
- reset the toggles when the API key is removed and surface disabled tooltips
- style the new controls to align with the existing AI panel visuals and focus states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9bc1ade3c8332b72e41a50fc36900