### PR TITLE
Update deploy workflow checks and triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:
@@ -44,6 +46,14 @@ jobs:
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
+      - name: Lint
+        working-directory: ${{ steps.wd.outputs.dir }}
+        run: npm run lint --if-present
+
+      - name: Test
+        working-directory: ${{ steps.wd.outputs.dir }}
+        run: npm test --if-present
+
       - name: Build
         working-directory: ${{ steps.wd.outputs.dir }}
         run: npm run build
@@ -68,6 +78,7 @@ jobs:
           path: ${{ steps.wd.outputs.dir }}/${{ steps.out.outputs.dir }}
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- add pull request trigger so the workflow runs on main-targeted PRs
- run npm lint and test scripts when available before building
- guard the deploy job so deployments only run for non-PR events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9ccc3e2b88332b0a34ea06dd83e25