### PR TITLE
Refine OCR workflow with shared helpers

### DIFF
--- a/src/lib/figmentParser.js
+++ b/src/lib/figmentParser.js
@@ -1,0 +1,9 @@
+cat > src/lib/figmentParser.js <<'EOF'
+// src/lib/figmentParser.js
+// Bridge: route old imports to the canonical OCR library.
+export {
+  parseMetrics,
+  sanitizeParsedMetrics,
+  initialAdvancedInputs
+} from './ocr';
+EOF


### PR DESCRIPTION
## Summary
- add an OCR utility that pre-processes screenshots and spins up a configured Tesseract worker
- introduce a Figment parser module that normalizes OCR text into numeric metrics
- update the app to consume the shared helpers and tighten numeric handling for advanced stats

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9ccc4cb2c8332bce57765342b0645