### PR TITLE
Add OCR parsing test and export parser utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import Tesseract from 'tesseract.js'
 import './App.css'
+import { clamp, initialAdvancedInputs, parseMetrics } from './lib/ocr.js'
 
 const WEIGHTS = {
   notdeployed: { F: 340 / 515, L: 175 / 515, D: 0 / 515 },
@@ -60,17 +61,6 @@ const ADVANCED_CLASSES = [
   },
 ]
 
-const initialAdvancedInputs = {
-  walletSize: '',
-  pnl: '',
-  unrealizedPnl: '',
-  totalTrades: '',
-  winTrades: '',
-  lossTrades: '',
-  date: '',
-  carry: '',
-}
-
 const initialWeightInputs = {
   founder: '50',
   investor: '35',
@@ -94,8 +84,6 @@ const integerFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 })
 
-const clamp = (value, min, max) => Math.min(max, Math.max(min, value))
-
 const formatCurrency = (value) => currencyFormatter.format(value)
 const formatPercent = (value) => percentFormatter.format(value)
 const formatInteger = (value) => integerFormatter.format(value)
@@ -113,177 +101,6 @@ const calcSplit = (profit, carryPct, scenarioKey) => {
   const total = founders + laura + damon
 
   return { founders, laura, damon, total, weights }
-}
-
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-const normalizeMagnitude = (raw) => {
-  if (!raw) return ''
-  const trimmed = raw.trim()
-  const magnitudeMatch = trimmed.match(/([kKmM])$/)
-  const isNegative = trimmed.startsWith('(') && trimmed.endsWith(')')
-  const sanitized = trimmed.replace(/[^0-9.+-]/g, '')
-  if (!sanitized) return ''
-  let numeric = Number(sanitized)
-  if (Number.isNaN(numeric)) return ''
-  if (isNegative && numeric > 0) {
-    numeric *= -1
-  }
-  if (!magnitudeMatch) {
-    return String(numeric)
-  }
-  const mag = magnitudeMatch[1].toLowerCase()
-  const multiplier = mag === 'k' ? 1_000 : 1_000_000
-  return String(numeric * multiplier)
-}
-
-const numericTokenRegex = /([-+]?[$]?\d[\d,]*(?:\.\d+)?(?:\s?[kKmM])?)/
-const percentTokenRegex = /([-+]?\d+(?:\.\d+)?)\s*%/
-
-const parseLabeledNumber = (text, labels) => {
-  const lines = text.split(/\r?\n/).map((line) => line.trim())
-
-  for (const label of labels) {
-    const labelLower = label.toLowerCase()
-    for (let index = 0; index < lines.length; index += 1) {
-      const current = lines[index]
-      const currentLower = current.toLowerCase()
-      if (!currentLower.includes(labelLower)) {
-        continue
-      }
-      const inlineMatch = current.match(numericTokenRegex)
-      if (inlineMatch?.[1]) {
-        const normalized = normalizeMagnitude(inlineMatch[1])
-        if (normalized) return normalized
-      }
-      const nextLine = lines[index + 1]
-      if (nextLine) {
-        const nextMatch = nextLine.match(numericTokenRegex)
-        if (nextMatch?.[1]) {
-          const normalized = normalizeMagnitude(nextMatch[1])
-          if (normalized) return normalized
-        }
-      }
-    }
-  }
-
-  for (const label of labels) {
-    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${numericTokenRegex.source}`, 'i')
-    const match = regex.exec(text)
-    if (match?.[1]) {
-      const normalized = normalizeMagnitude(match[1])
-      if (normalized) return normalized
-    }
-  }
-
-  return ''
-}
-
-const parsePercentage = (text, labels) => {
-  const lines = text.split(/\r?\n/).map((line) => line.trim())
-
-  for (const label of labels) {
-    const labelLower = label.toLowerCase()
-    for (let index = 0; index < lines.length; index += 1) {
-      const current = lines[index]
-      const currentLower = current.toLowerCase()
-      if (!currentLower.includes(labelLower)) {
-        continue
-      }
-      const inlineMatch = current.match(percentTokenRegex)
-      if (inlineMatch?.[1]) {
-        return inlineMatch[1]
-      }
-      const nextLine = lines[index + 1]
-      if (nextLine) {
-        const nextMatch = nextLine.match(percentTokenRegex)
-        if (nextMatch?.[1]) {
-          return nextMatch[1]
-        }
-      }
-    }
-  }
-
-  for (const label of labels) {
-    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${percentTokenRegex.source}`, 'i')
-    const match = regex.exec(text)
-    if (match?.[1]) {
-      return match[1]
-    }
-  }
-
-  return ''
-}
-
-const parseDate = (text) => {
-  const iso = text.match(/\b\d{4}-\d{2}-\d{2}\b/)
-  if (iso) return iso[0]
-
-  const slash = text.match(/\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/)
-  if (slash) return slash[0]
-
-  const month = text.match(
-    /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2},?\s+\d{2,4}\b/i,
-  )
-  if (month) return month[0]
-
-  return ''
-}
-
-const extractAdvancedFields = (text) => {
-  if (!text) {
-    return initialAdvancedInputs
-  }
-
-  const normalizedText = text.replace(/\r?\n/g, '\n')
-
-  const walletSize = parseLabeledNumber(normalizedText, [
-    'wallet size',
-    'wallet balance',
-    'wallet',
-  ])
-  const pnl = parseLabeledNumber(normalizedText, [
-    'realized pnl',
-    'net pnl',
-    'pnl',
-    'p/l',
-    'profit',
-  ])
-  const unrealizedPnl = parseLabeledNumber(normalizedText, [
-    'unrealized pnl',
-    'unrealized p/l',
-    'unrealized',
-  ])
-  const totalTrades = parseLabeledNumber(normalizedText, [
-    'total trades',
-    'trades total',
-    'trade count',
-    'trades',
-  ])
-  const winTrades = parseLabeledNumber(normalizedText, [
-    'win trades',
-    'winning trades',
-    'wins',
-  ])
-  const lossTrades = parseLabeledNumber(normalizedText, [
-    'loss trades',
-    'losing trades',
-    'losses',
-  ])
-  const carryRaw = parsePercentage(normalizedText, ['carry', 'carry %', 'carry percent'])
-  const carry = carryRaw ? String(clamp(Number(carryRaw) || 0, 0, 100)) : ''
-  const date = parseDate(text)
-
-  return {
-    walletSize,
-    pnl,
-    unrealizedPnl,
-    totalTrades,
-    winTrades,
-    lossTrades,
-    date,
-    carry,
-  }
 }
 
 const sanitizeNumericInput = (value) => {
@@ -773,7 +590,7 @@ function App() {
 
       const text = result.data.text ?? ''
       setOcrText(text)
-      const extracted = extractAdvancedFields(text)
+      const extracted = parseMetrics(text)
       setAdvancedInputs((previous) => {
         const next = { ...previous }
         Object.entries(extracted).forEach(([key, value]) => {

--- a/src/lib/ocr.js
+++ b/src/lib/ocr.js
@@ -1,0 +1,183 @@
+export const clamp = (value, min, max) => Math.min(max, Math.max(min, value))
+
+export const initialAdvancedInputs = {
+  walletSize: '',
+  pnl: '',
+  unrealizedPnl: '',
+  totalTrades: '',
+  winTrades: '',
+  lossTrades: '',
+  date: '',
+  carry: '',
+}
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const normalizeMagnitude = (raw) => {
+  if (!raw) return ''
+  const trimmed = raw.trim()
+  const magnitudeMatch = trimmed.match(/([kKmM])$/)
+  const isNegative = trimmed.startsWith('(') && trimmed.endsWith(')')
+  const sanitized = trimmed.replace(/[^0-9.+-]/g, '')
+  if (!sanitized) return ''
+  let numeric = Number(sanitized)
+  if (Number.isNaN(numeric)) return ''
+  if (isNegative && numeric > 0) {
+    numeric *= -1
+  }
+  if (!magnitudeMatch) {
+    return String(numeric)
+  }
+  const mag = magnitudeMatch[1].toLowerCase()
+  const multiplier = mag === 'k' ? 1_000 : 1_000_000
+  return String(numeric * multiplier)
+}
+
+const numericTokenRegex = /([-+]?[$]?\d[\d,]*(?:\.\d+)?(?:\s?[kKmM])?)/
+const percentTokenRegex = /([-+]?\d+(?:\.\d+)?)\s*%/
+
+const parseLabeledNumber = (text, labels) => {
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+
+  for (const label of labels) {
+    const labelLower = label.toLowerCase()
+    for (let index = 0; index < lines.length; index += 1) {
+      const current = lines[index]
+      const currentLower = current.toLowerCase()
+      if (!currentLower.includes(labelLower)) {
+        continue
+      }
+      const inlineMatch = current.match(numericTokenRegex)
+      if (inlineMatch?.[1]) {
+        const normalized = normalizeMagnitude(inlineMatch[1])
+        if (normalized) return normalized
+      }
+      const nextLine = lines[index + 1]
+      if (nextLine) {
+        const nextMatch = nextLine.match(numericTokenRegex)
+        if (nextMatch?.[1]) {
+          const normalized = normalizeMagnitude(nextMatch[1])
+          if (normalized) return normalized
+        }
+      }
+    }
+  }
+
+  for (const label of labels) {
+    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${numericTokenRegex.source}`, 'i')
+    const match = regex.exec(text)
+    if (match?.[1]) {
+      const normalized = normalizeMagnitude(match[1])
+      if (normalized) return normalized
+    }
+  }
+
+  return ''
+}
+
+const parsePercentage = (text, labels) => {
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+
+  for (const label of labels) {
+    const labelLower = label.toLowerCase()
+    for (let index = 0; index < lines.length; index += 1) {
+      const current = lines[index]
+      const currentLower = current.toLowerCase()
+      if (!currentLower.includes(labelLower)) {
+        continue
+      }
+      const inlineMatch = current.match(percentTokenRegex)
+      if (inlineMatch?.[1]) {
+        return inlineMatch[1]
+      }
+      const nextLine = lines[index + 1]
+      if (nextLine) {
+        const nextMatch = nextLine.match(percentTokenRegex)
+        if (nextMatch?.[1]) {
+          return nextMatch[1]
+        }
+      }
+    }
+  }
+
+  for (const label of labels) {
+    const regex = new RegExp(`\\b${escapeRegex(label)}\\b[\\s:=\u2013-]*${percentTokenRegex.source}`, 'i')
+    const match = regex.exec(text)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+
+  return ''
+}
+
+const parseDateToken = (text) => {
+  const iso = text.match(/\b\d{4}-\d{2}-\d{2}\b/)
+  if (iso) return iso[0]
+
+  const slash = text.match(/\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/)
+  if (slash) return slash[0]
+
+  const month = text.match(
+    /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2},?\s+\d{2,4}\b/i,
+  )
+  if (month) return month[0]
+
+  return ''
+}
+
+export const parseMetrics = (text) => {
+  if (!text) {
+    return initialAdvancedInputs
+  }
+
+  const normalizedText = text.replace(/\r?\n/g, '\n')
+
+  const walletSize = parseLabeledNumber(normalizedText, [
+    'wallet size',
+    'wallet balance',
+    'wallet',
+  ])
+  const pnl = parseLabeledNumber(normalizedText, [
+    'realized pnl',
+    'net pnl',
+    'pnl',
+    'p/l',
+    'profit',
+  ])
+  const unrealizedPnl = parseLabeledNumber(normalizedText, [
+    'unrealized pnl',
+    'unrealized p/l',
+    'unrealized',
+  ])
+  const totalTrades = parseLabeledNumber(normalizedText, [
+    'total trades',
+    'trades total',
+    'trade count',
+    'trades',
+  ])
+  const winTrades = parseLabeledNumber(normalizedText, [
+    'win trades',
+    'winning trades',
+    'wins',
+  ])
+  const lossTrades = parseLabeledNumber(normalizedText, [
+    'loss trades',
+    'losing trades',
+    'losses',
+  ])
+  const carryRaw = parsePercentage(normalizedText, ['carry', 'carry %', 'carry percent'])
+  const carry = carryRaw ? String(clamp(Number(carryRaw) || 0, 0, 100)) : ''
+  const date = parseDateToken(text)
+
+  return {
+    walletSize,
+    pnl,
+    unrealizedPnl,
+    totalTrades,
+    winTrades,
+    lossTrades,
+    date,
+    carry,
+  }
+}

--- a/tests/ocr-parsing.test.js
+++ b/tests/ocr-parsing.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseMetrics } from '../src/lib/ocr.js'
+
+test('parseMetrics normalizes OCR numbers and surfaces ISO date', () => {
+  const text = `
+  FIGMENT TRADING SNAPSHOT
+  Snapshot captured: 2024-09-15 at 09:45 UTC
+
+  Wallet Balance
+  $4.8k USD
+
+  Realized PnL .......... +$1.9k
+  Unrealized P/L est.
+  (650)
+
+  Trades total
+  24 executed
+  Win trades
+  18
+  Loss trades
+  6
+
+  Carry Percent : 12.5 %
+  `
+
+  const metrics = parseMetrics(text)
+
+  assert.deepStrictEqual(metrics, {
+    walletSize: '4800',
+    pnl: '1900',
+    unrealizedPnl: '650',
+    totalTrades: '24',
+    winTrades: '18',
+    lossTrades: '6',
+    date: '2024-09-15',
+    carry: '12.5',
+  })
+})


### PR DESCRIPTION
## Summary
- extract the OCR metric parsing helpers into `src/lib/ocr.js` and export the clamp utility and defaults for reuse
- update the React app to consume the shared parser and expose it for testing, and wire up `node --test` in the scripts
- add a Node test that feeds noisy OCR text to `parseMetrics` and verifies the normalized figures and ISO-formatted date

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9cccc2d348332b6ac2b32fe8292c6