### PR TITLE
Improve OCR metric merging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -592,13 +592,10 @@ function App() {
       setOcrText(text)
       const extracted = parseMetrics(text)
       setAdvancedInputs((previous) => {
-        const next = { ...previous }
-        Object.entries(extracted).forEach(([key, value]) => {
-          if (value !== '') {
-            next[key] = value
-          }
-        })
-        return next
+        const updates = Object.fromEntries(
+          Object.entries(extracted).filter(([, value]) => value !== ''),
+        )
+        return { ...previous, ...updates }
       })
 
       if (extracted.pnl) {
@@ -607,7 +604,7 @@ function App() {
       }
 
       if (extracted.carry) {
-        setCarryInput(extracted.carry)
+        setCarryInput(String(extracted.carry))
       }
 
       setOcrStatus('done')


### PR DESCRIPTION
## Summary
- merge parsed OCR metrics into advanced inputs using the extracted snapshot
- ensure the carry input continues to consume the extracted OCR value as a string

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9dcde50908332af83778938975faa