### PR TITLE
Add auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,18 @@
+name: Enable auto-merge
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          merge-method: squash


### PR DESCRIPTION
## Summary
- add an auto-merge workflow triggered by `pull_request_target` events
- enable squash auto-merge for pull requests labeled `automerge`

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9edd5e7508332a4c0830ef39d9a01