### PR TITLE
Extract allocation helpers and add tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,8 @@ import { useEffect, useMemo, useState } from 'react'
 import Tesseract from 'tesseract.js'
 import './App.css'
 import { clamp, initialAdvancedInputs, parseMetrics, sanitizeParsedMetrics } from './lib/ocr.js'
-
-const WEIGHTS = {
-  notdeployed: { F: 340 / 515, L: 175 / 515, D: 0 / 515 },
-  deployed: { F: 340 / 570, L: 175 / 570, D: 55 / 570 },
-}
+import { normalizeWeightInputs } from './lib/weights.js'
+import { calcSplit, calculateAdvancedMetrics, parseAdvancedInputs } from './lib/alloc.js'
 
 const PARTIES = [
   { key: 'founders', label: 'Founders (Yoni+Spence)', className: 'founders' },
@@ -89,19 +86,6 @@ const formatPercent = (value) => percentFormatter.format(value)
 const formatInteger = (value) => integerFormatter.format(value)
 
 const formatWeightForCsv = (value) => `${(value * 100).toFixed(4)}%`
-
-const getWeights = (scenarioKey) => WEIGHTS[scenarioKey] ?? WEIGHTS.notdeployed
-
-const calcSplit = (profit, carryPct, scenarioKey) => {
-  const weights = getWeights(scenarioKey)
-  const carry = (carryPct || 0) / 100
-  const founders = profit * (weights.F + carry * (weights.L + weights.D))
-  const laura = profit * ((1 - carry) * weights.L)
-  const damon = profit * ((1 - carry) * weights.D)
-  const total = founders + laura + damon
-
-  return { founders, laura, damon, total, weights }
-}
 
 const sanitizeNumericInput = (value) => {
   if (!value) return ''
@@ -517,48 +501,17 @@ function App() {
   }
   const scenarioDetails = SCENARIOS.find((option) => option.key === scenario) ?? SCENARIOS[0]
 
-  const advancedNumbers = useMemo(
-    () => ({
-      walletSize: Number(advancedInputs.walletSize) || 0,
-      pnl: Number(advancedInputs.pnl) || 0,
-      unrealizedPnl: Number(advancedInputs.unrealizedPnl) || 0,
-      totalTrades: Number(advancedInputs.totalTrades) || 0,
-      winTrades: Number(advancedInputs.winTrades) || 0,
-      lossTrades: Number(advancedInputs.lossTrades) || 0,
-      carry: Number(advancedInputs.carry) || 0,
-    }),
-    [advancedInputs],
-  )
+  const advancedNumbers = useMemo(() => parseAdvancedInputs(advancedInputs), [advancedInputs])
 
-  const weightNumbers = useMemo(
-    () => ({
-      founder: Math.max(0, Number(weightInputs.founder) || 0),
-      investor: Math.max(0, Number(weightInputs.investor) || 0),
-      moonbag: Math.max(0, Number(weightInputs.moonbag) || 0),
-    }),
+  const normalizedWeights = useMemo(
+    () => normalizeWeightInputs(weightInputs).normalized,
     [weightInputs],
   )
 
-  const weightSum = weightNumbers.founder + weightNumbers.investor + weightNumbers.moonbag
-  const normalizedWeights = weightSum > 0
-    ? {
-        founder: weightNumbers.founder / weightSum,
-        investor: weightNumbers.investor / weightSum,
-        moonbag: weightNumbers.moonbag / weightSum,
-      }
-    : { founder: 0, investor: 0, moonbag: 0 }
-
-  const combinedProfit = advancedNumbers.pnl + advancedNumbers.unrealizedPnl
-  const advancedDistribution = {
-    founder: combinedProfit * normalizedWeights.founder,
-    investor: combinedProfit * normalizedWeights.investor,
-    moonbag: combinedProfit * normalizedWeights.moonbag,
-  }
-
-  const winRate = advancedNumbers.totalTrades > 0 ? advancedNumbers.winTrades / advancedNumbers.totalTrades : 0
-  const lossRate = advancedNumbers.totalTrades > 0 ? advancedNumbers.lossTrades / advancedNumbers.totalTrades : 0
-  const profitPerTrade = advancedNumbers.totalTrades > 0 ? advancedNumbers.pnl / advancedNumbers.totalTrades : 0
-  const roi = advancedNumbers.walletSize > 0 ? combinedProfit / advancedNumbers.walletSize : 0
+  const { combinedProfit, advancedDistribution, winRate, lossRate, profitPerTrade, roi } = useMemo(
+    () => calculateAdvancedMetrics(advancedNumbers, normalizedWeights),
+    [advancedNumbers, normalizedWeights],
+  )
 
   const handleOcrUpload = async (event) => {
     const inputElement = event.target

--- a/src/lib/alloc.js
+++ b/src/lib/alloc.js
@@ -1,0 +1,54 @@
+import { getWeights } from './weights.js'
+
+export const calcSplit = (profit, carryPct, scenarioKey) => {
+  const weights = getWeights(scenarioKey)
+  const carry = (carryPct || 0) / 100
+  const founders = profit * (weights.F + carry * (weights.L + weights.D))
+  const laura = profit * ((1 - carry) * weights.L)
+  const damon = profit * ((1 - carry) * weights.D)
+  const total = founders + laura + damon
+
+  return { founders, laura, damon, total, weights }
+}
+
+export const parseAdvancedInputs = (inputs = {}) => ({
+  walletSize: Number(inputs.walletSize) || 0,
+  pnl: Number(inputs.pnl) || 0,
+  unrealizedPnl: Number(inputs.unrealizedPnl) || 0,
+  totalTrades: Number(inputs.totalTrades) || 0,
+  winTrades: Number(inputs.winTrades) || 0,
+  lossTrades: Number(inputs.lossTrades) || 0,
+  carry: Number(inputs.carry) || 0,
+})
+
+export const calculateCombinedProfit = (advancedNumbers) =>
+  advancedNumbers.pnl + advancedNumbers.unrealizedPnl
+
+export const distributeCombinedProfit = (combinedProfit, normalizedWeights) => ({
+  founder: combinedProfit * (normalizedWeights.founder || 0),
+  investor: combinedProfit * (normalizedWeights.investor || 0),
+  moonbag: combinedProfit * (normalizedWeights.moonbag || 0),
+})
+
+export const calculateWinRate = (winTrades, totalTrades) =>
+  totalTrades > 0 ? winTrades / totalTrades : 0
+
+export const calculateLossRate = (lossTrades, totalTrades) =>
+  totalTrades > 0 ? lossTrades / totalTrades : 0
+
+export const calculateProfitPerTrade = (pnl, totalTrades) =>
+  totalTrades > 0 ? pnl / totalTrades : 0
+
+export const calculateRoi = (combinedProfit, walletSize) =>
+  walletSize > 0 ? combinedProfit / walletSize : 0
+
+export const calculateAdvancedMetrics = (advancedNumbers, normalizedWeights) => {
+  const combinedProfit = calculateCombinedProfit(advancedNumbers)
+  const advancedDistribution = distributeCombinedProfit(combinedProfit, normalizedWeights)
+  const winRate = calculateWinRate(advancedNumbers.winTrades, advancedNumbers.totalTrades)
+  const lossRate = calculateLossRate(advancedNumbers.lossTrades, advancedNumbers.totalTrades)
+  const profitPerTrade = calculateProfitPerTrade(advancedNumbers.pnl, advancedNumbers.totalTrades)
+  const roi = calculateRoi(combinedProfit, advancedNumbers.walletSize)
+
+  return { combinedProfit, advancedDistribution, winRate, lossRate, profitPerTrade, roi }
+}

--- a/src/lib/weights.js
+++ b/src/lib/weights.js
@@ -1,0 +1,37 @@
+const SCENARIO_WEIGHTS = {
+  notdeployed: { F: 340 / 515, L: 175 / 515, D: 0 / 515 },
+  deployed: { F: 340 / 570, L: 175 / 570, D: 55 / 570 },
+}
+
+const ZERO_NORMALIZED_WEIGHTS = { founder: 0, investor: 0, moonbag: 0 }
+
+export const getWeights = (scenarioKey) => SCENARIO_WEIGHTS[scenarioKey] ?? SCENARIO_WEIGHTS.notdeployed
+
+export const parseWeightInputs = (inputs = {}) => ({
+  founder: Math.max(0, Number(inputs.founder) || 0),
+  investor: Math.max(0, Number(inputs.investor) || 0),
+  moonbag: Math.max(0, Number(inputs.moonbag) || 0),
+})
+
+export const normalizeWeightNumbers = (numbers) => {
+  const sum = numbers.founder + numbers.investor + numbers.moonbag
+  if (sum <= 0) {
+    return { ...ZERO_NORMALIZED_WEIGHTS }
+  }
+
+  return {
+    founder: numbers.founder / sum,
+    investor: numbers.investor / sum,
+    moonbag: numbers.moonbag / sum,
+  }
+}
+
+export const normalizeWeightInputs = (inputs = {}) => {
+  const numbers = parseWeightInputs(inputs)
+  const sum = numbers.founder + numbers.investor + numbers.moonbag
+  const normalized = sum > 0 ? normalizeWeightNumbers(numbers) : { ...ZERO_NORMALIZED_WEIGHTS }
+
+  return { numbers, normalized, sum }
+}
+
+export { SCENARIO_WEIGHTS }

--- a/tests/alloc.test.js
+++ b/tests/alloc.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { calcSplit, calculateAdvancedMetrics, parseAdvancedInputs } from '../src/lib/alloc.js'
+import { getWeights, normalizeWeightInputs } from '../src/lib/weights.js'
+
+test('calcSplit applies carry routing across scenarios', () => {
+  const profit = 1000
+  const carry = 20
+  const { founders, laura, damon, total, weights } = calcSplit(profit, carry, 'deployed')
+
+  assert.ok(Math.abs(total - profit) < 1e-9)
+
+  const expectedWeights = getWeights('deployed')
+  assert.deepEqual(weights, expectedWeights)
+
+  assert.ok(Math.abs(founders - 677.1929824561404) < 1e-9)
+  assert.ok(Math.abs(laura - 245.61403508771932) < 1e-9)
+  assert.ok(Math.abs(damon - 77.19298245614036) < 1e-9)
+})
+
+test('normalizeWeightInputs produces normalized shares and clamps invalid entries', () => {
+  const { normalized } = normalizeWeightInputs({ founder: '50', investor: '30', moonbag: '20' })
+
+  assert.ok(Math.abs(normalized.founder - 0.5) < 1e-12)
+  assert.ok(Math.abs(normalized.investor - 0.3) < 1e-12)
+  assert.ok(Math.abs(normalized.moonbag - 0.2) < 1e-12)
+
+  const zeroed = normalizeWeightInputs({ founder: '-10', investor: '', moonbag: null })
+  assert.deepEqual(zeroed.normalized, { founder: 0, investor: 0, moonbag: 0 })
+})
+
+test('calculateAdvancedMetrics summarizes combined profit distribution and ratios', () => {
+  const advancedNumbers = parseAdvancedInputs({
+    walletSize: '5000',
+    pnl: '1000',
+    unrealizedPnl: '500',
+    totalTrades: '10',
+    winTrades: '7',
+    lossTrades: '3',
+  })
+
+  const normalizedWeights = { founder: 0.5, investor: 0.3, moonbag: 0.2 }
+  const metrics = calculateAdvancedMetrics(advancedNumbers, normalizedWeights)
+
+  assert.ok(Math.abs(metrics.combinedProfit - 1500) < 1e-9)
+  assert.ok(Math.abs(metrics.advancedDistribution.founder - 750) < 1e-9)
+  assert.ok(Math.abs(metrics.advancedDistribution.investor - 450) < 1e-9)
+  assert.ok(Math.abs(metrics.advancedDistribution.moonbag - 300) < 1e-9)
+  assert.ok(Math.abs(metrics.winRate - 0.7) < 1e-9)
+  assert.ok(Math.abs(metrics.lossRate - 0.3) < 1e-9)
+  assert.ok(Math.abs(metrics.profitPerTrade - 100) < 1e-9)
+  assert.ok(Math.abs(metrics.roi - 0.3) < 1e-9)
+})
+
+test('calculateAdvancedMetrics guards against divide-by-zero scenarios', () => {
+  const metrics = calculateAdvancedMetrics(
+    parseAdvancedInputs({ walletSize: '0', pnl: '0', unrealizedPnl: '0', totalTrades: '0' }),
+    normalizeWeightInputs({}).normalized,
+  )
+
+  assert.deepEqual(metrics.advancedDistribution, { founder: 0, investor: 0, moonbag: 0 })
+  assert.equal(metrics.combinedProfit, 0)
+  assert.equal(metrics.winRate, 0)
+  assert.equal(metrics.lossRate, 0)
+  assert.equal(metrics.profitPerTrade, 0)
+  assert.equal(metrics.roi, 0)
+})


### PR DESCRIPTION
## Summary
- extract scenario weight normalization utilities into `src/lib/weights.js`
- add allocation helpers for profit split and advanced metrics in `src/lib/alloc.js`
- refactor `App.jsx` to consume the shared helpers and add focused unit tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cabdf8655c83329f44185768a4ccdb